### PR TITLE
Add customisation of index and team layout pages

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -9,6 +9,7 @@ title = "Hugo Serif Theme"
 
   [params.homepage]
     show_call_box = true
+    hide_view_all_services = false  # set to true to hide the View All Services button
 
   [params.logo]
     mobile = "images/logo/logo-mobile.svg"
@@ -26,6 +27,9 @@ title = "Hugo Serif Theme"
     meta_twitter_card = "summary"
     meta_twitter_site = "@zerostaticio"
     meta_twitter_creator = "@zerostaticio"
+
+  [params.team]
+    summary_large_truncate = 120  # How many characters to include in the summary of the team bios (large layout) before truncating
 
   [params.footer]
     copyright_text = 'Free Hugo theme by <a class="zerostatic" href="https://www.zerostatic.io">www.zerostatic.io</a>'

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -44,11 +44,13 @@
       </div>
       {{ end }}
     </div>
+    {{ if not .Site.Params.homepage.hide_view_all_services }}
     <div class="row justify-content-center">
       <div class="col-auto">
         <a class="button button-primary" href="{{ "services/" | relURL }}">View All Services</a>
       </div>
     </div>
+    {{ end }}
   </div>
 </div>
 {{end}}

--- a/layouts/team/summary-large.html
+++ b/layouts/team/summary-large.html
@@ -9,6 +9,9 @@
     <p class="team-description">{{ .Params.Jobtitle }}</p>
     {{ if .Params.Linkedinurl }}
     <a target="_blank" href="{{ .Params.Linkedinurl }}">LinkedIn</a> {{ end }}
+    {{ if .Params.Twitterhandle }}
+    <a target="_blank" href="https://twitter.com/{{ .Params.Twitterhandle }}">Twitter</a> {{ end }}
+
   </div>
-  <div class="team-content">    {{ .Content | truncate 120 "…" }}</div>
+  <div class="team-content">    {{ .Content | truncate (.Site.Params.team.summary_large_truncate | default 120 ) "…" }}</div>
 </div>

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -55,6 +55,9 @@ models:
               - type: boolean
                 name: show_call_box
                 label: Show Callbox on Homepage?
+              - type: boolean
+                name: hide_view_all_services
+                label: Show View All Services button on Homepage?
           - type: object
             name: logo
             label: Params Logo
@@ -105,6 +108,13 @@ models:
               - type: string
                 name: meta_twitter_creator
                 label: meta_twitter_creator
+          - type: object
+            name: team
+            label: Team Page Params
+            fields:
+              - type: number
+                name: summary_large_truncate
+                label: Length (chars) of bio text
           - type: object
             name: footer
             label: Footer

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -325,6 +325,9 @@ models:
       - type: string
         name: linkedinurl
         label: Linkedin URL
+      - type: string
+        name: Twitterhandle
+        label: Twitter handle
       - type: boolean
         name: draft
         label: Draft


### PR DESCRIPTION
For the RSSE Africa page that I created based on this theme I had to add a few customization:

1. The ability to switch off the "View all services" button
2. A Twitter link for team members
3. The ability to set the length of the team member summary

This PR provides all of those options and adds them to the Stackbit config. I'm contributing them in the hope that others might find them useful.

I haven't added these extra options to the config.toml or README but can add that documentation if desired.