### PR TITLE
Fix typo in mobile font size

### DIFF
--- a/assets/scss/components/_type.scss
+++ b/assets/scss/components/_type.scss
@@ -8,7 +8,7 @@ p {
   margin-bottom: 20px;
 }
 h1 {
-  font-size: 20px;
+  font-size: 24px;
   font-family: $font-family-heading;
   line-height: 1.2;
   margin-bottom: 20px;
@@ -18,7 +18,7 @@ h1 {
   }
 }
 h2 {
-  font-size: 24px;
+  font-size: 20px;
   font-family: $font-family-heading;
   line-height: 1.4;
   margin-bottom: 10px;


### PR DESCRIPTION
Hi,

I think the font size for `h1` and `h2` in the mobile context are inverted.
This PR proposes to fix them