### PR TITLE
Make Google Fonts optional

### DIFF
--- a/layouts/partials/google-fonts.html
+++ b/layouts/partials/google-fonts.html
@@ -1,5 +1,5 @@
-{{ with .Site.Params.fonts }}
+{{ with .Site.Params.fonts.google_fonts }}
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="{{ .google_fonts }}" rel="stylesheet">
+  <link href="{{ . }}" rel="stylesheet">
 {{ end }}


### PR DESCRIPTION
This allows users to disable Google Fonts if they don't need it.