### PR TITLE
Simplify template logic

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -11,13 +11,12 @@
   {{ partial "google-fonts.html" . }}
 
   <!-- CSS-->
-  {{ if .Site.IsServer }}
-  {{ $style := resources.Get "scss/style.scss" | resources.ExecuteAsTemplate "style.scss" . | toCSS (dict "targetPath" "css/style.css" "enableSourceMap" true) }}
-  <link rel="stylesheet" href="{{ ($style).RelPermalink }}">
-  {{ else }}
-  {{ $style := resources.Get "scss/style.scss" | resources.ExecuteAsTemplate "style.scss" . | toCSS (dict "targetPath" "css/style.css" "enableSourceMap" false) }}
-  <link rel="stylesheet" href="{{ ($style | minify | fingerprint).RelPermalink }}">
+  {{ $css_options := dict "targetPath" "css/style.css" "enableSourceMap" (not hugo.IsProduction) }}
+  {{ $style := resources.Get "scss/style.scss" | resources.ExecuteAsTemplate "style.scss" . | toCSS $css_options }}
+  {{ if hugo.IsProduction }}
+    {{ $style = $style | minify | fingerprint }}
   {{ end }}
+  <link rel="stylesheet" href="{{ $style.RelPermalink }}">
 
   {{ block "header_css" . }}{{ end }}
 
@@ -51,11 +50,10 @@
   {{ block "footer_js" . }}
   {{ end }}
 
-  {{ if .Site.IsServer }}
-  <script type="text/javascript" src="{{ $scripts.RelPermalink }}"></script>
-  {{ else }}
-  <script type="text/javascript" src="{{ ($scripts | minify | fingerprint).RelPermalink }}"></script>
+  {{ if hugo.IsProduction }}
+    {{ $scripts = $scripts | minify | fingerprint }}
   {{ end }}
+  <script type="text/javascript" src="{{ $scripts.RelPermalink }}"></script>
 
   {{ partial "google-tag-manager.html" . }}
   {{ partial "google-analytics.html" . }}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8">
   <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <title>{{ block "title" . }}{{ if .Params.meta_title }}{{ .Params.meta_title }}{{ else }}{{ .Title }} - {{ .Site.Title }}{{ end }}{{ end }}</title>
+  <title>{{ block "title" . }}{{ .Params.meta_title | default (printf "%s - %s" .Title .Site.Title) }}{{ end }}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/png" href="{{ "favicon-32x32.svg" | relURL }}">
 
@@ -22,15 +22,15 @@
   {{ block "header_css" . }}{{ end }}
 
   {{ block "meta_tags" . }}
-    {{ if .Params.description }}<meta name="description" content="{{ .Params.description }}"/>{{ end }}
-    {{ if .Params.meta_title }}<meta property="og:title" content="{{ .Params.meta_title }}"/>{{ else }}<meta property="og:title" content="{{ .Title }}"/>{{ end }}
+    {{ with .Params.description }}<meta name="description" content="{{ . }}"/>{{ end }}
+    <meta property="og:title" content="{{ .Params.meta_title | default .Title }}"/>
     <meta property="og:type" content="website"/>
     <meta property="og:url" content="{{ .Permalink }}"/>
-    {{ if .Params.image }}<meta property="og:image" content="{{ .Params.image | absURL }}"/>{{ else if .Site.Params.seo.meta_og_image }}<meta property="og:image" content="{{ .Site.Params.seo.meta_og_image | absURL }}"/>{{ end }}
-    {{ if .Params.description }}<meta property="og:description" content="{{ .Params.description }}"/>{{ end }}
+    {{ with .Params.image | default .Site.Params.seo.meta_og_image }}<meta property="og:image" content="{{ . | absURL }}"/>{{ end }}
+    {{ with .Params.description }}<meta property="og:description" content="{{ . }}"/>{{ end }}
     <meta name="twitter:card" content="summary"/>
-    {{ if .Site.Params.seo.meta_twitter_site }}<meta name="twitter:site" content="{{ .Site.Params.seo.meta_twitter_site }}"/>{{ end }}
-    {{ if .Site.Params.seo.meta_twitter_creator }}<meta name="twitter:creator" content="{{ .Site.Params.seo.meta_twitter_creator }}"/>{{ end }}
+    {{ with .Site.Params.seo.meta_twitter_site }}<meta name="twitter:site" content="{{ . }}"/>{{ end }}
+    {{ with .Site.Params.seo.meta_twitter_creator }}<meta name="twitter:creator" content="{{ . }}"/>{{ end }}
   {{ end }}
 
 </head>

--- a/layouts/partials/google-analytics.html
+++ b/layouts/partials/google-analytics.html
@@ -1,4 +1,4 @@
-{{- if not .Site.IsServer -}}
+{{- if and (not .Site.IsServer) hugo.IsProduction -}}
 {{ with getenv "HUGO_GOOGLE_ANALYTICS_ID" | default .Site.Params.google_analytics_id }}
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id={{- . -}}"></script>

--- a/layouts/partials/google-analytics.html
+++ b/layouts/partials/google-analytics.html
@@ -1,10 +1,7 @@
-{{- if .Site.IsServer -}}
-<!-- Dont add Google analytics to localhost -->
-{{ else }}
-{{ $gid := (getenv "HUGO_GOOGLE_ANALYTICS_ID") }}
-{{ if $gid }}
+{{- if not .Site.IsServer -}}
+{{ with getenv "HUGO_GOOGLE_ANALYTICS_ID" | default .Site.Params.google_analytics_id }}
 <!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id={{- $gid -}}"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id={{- . -}}"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
 
@@ -12,21 +9,7 @@
     dataLayer.push(arguments);
   }
   gtag('js', new Date());
-  gtag('config', '{{- $gid -}}');
-</script>
-{{ else }}
-{{ if .Site.Params.google_analytics_id }}
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id={{- .Site.Params.google_analytics_id -}}"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-
-  function gtag() {
-    dataLayer.push(arguments);
-  }
-  gtag('js', new Date());
-  gtag('config', '{{- .Site.Params.google_analytics_id -}}');
+  gtag('config', '{{ . }}');
 </script>
 {{ end }}
-{{ end}}
 {{ end }}

--- a/layouts/partials/google-tag-manager-noscript.html
+++ b/layouts/partials/google-tag-manager-noscript.html
@@ -1,4 +1,4 @@
-{{- if not .Site.IsServer -}}
+{{- if and (not .Site.IsServer) hugo.IsProduction -}}
 {{ with getenv "HUGO_GTM_ID" | default .Site.Params.google_tag_manager_id }}
 <!-- Google Tag Manager (noscript) --> <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ . }}" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript> <!-- End Google Tag Manager (noscript) -->
 {{ end }}

--- a/layouts/partials/google-tag-manager-noscript.html
+++ b/layouts/partials/google-tag-manager-noscript.html
@@ -1,12 +1,5 @@
-{{- if .Site.IsServer -}}
-<!-- Dont add Google Tag Manager to localhost -->
-{{ else }}
-{{ $gid := (getenv "HUGO_GTM_ID") }}
-{{ if $gid }}
-<!-- Google Tag Manager (noscript) --> <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{- $gid -}}" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript> <!-- End Google Tag Manager (noscript) -->
-{{ else }}
-{{ if .Site.Params.google_tag_manager_id }}
-<!-- Google Tag Manager (noscript) --> <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{- .Site.Params.google_tag_manager_id -}}" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript> <!-- End Google Tag Manager (noscript) -->
-{{ end }}
+{{- if not .Site.IsServer -}}
+{{ with getenv "HUGO_GTM_ID" | default .Site.Params.google_tag_manager_id }}
+<!-- Google Tag Manager (noscript) --> <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ . }}" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript> <!-- End Google Tag Manager (noscript) -->
 {{ end }}
 {{ end }}

--- a/layouts/partials/google-tag-manager.html
+++ b/layouts/partials/google-tag-manager.html
@@ -1,12 +1,5 @@
-{{- if .Site.IsServer -}}
-<!-- Dont add Google Tag Manager to localhost -->
-{{ else }}
-{{ $gid := (getenv "HUGO_GTM_ID") }}
-{{ if $gid }}
-<!-- Google Tag Manager --> <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src= 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer','{{- $gid -}}');</script> <!-- End Google Tag Manager -->
-{{ else }}
-{{ if .Site.Params.google_tag_manager_id }}
-<!-- Google Tag Manager --> <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src= 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer','{{- .Site.Params.google_tag_manager_id -}}');</script> <!-- End Google Tag Manager -->
-{{ end }}
+{{- if not .Site.IsServer -}}
+{{ with getenv "HUGO_GTM_ID" | default .Site.Params.google_tag_manager_id }}
+<!-- Google Tag Manager --> <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src= 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer','{{ . }}');</script> <!-- End Google Tag Manager -->
 {{ end }}
 {{ end }}

--- a/layouts/partials/google-tag-manager.html
+++ b/layouts/partials/google-tag-manager.html
@@ -1,4 +1,4 @@
-{{- if not .Site.IsServer -}}
+{{- if and (not .Site.IsServer) hugo.IsProduction -}}
 {{ with getenv "HUGO_GTM_ID" | default .Site.Params.google_tag_manager_id }}
 <!-- Google Tag Manager --> <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src= 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer','{{ . }}');</script> <!-- End Google Tag Manager -->
 {{ end }}

--- a/layouts/partials/sub-footer.html
+++ b/layouts/partials/sub-footer.html
@@ -6,8 +6,8 @@
           {{ if .Site.Data.social }}
             {{ partial "social.html" . }}
           {{ end }}
-          {{ if .Site.Params.footer.copyright_text }}
-            <div class="copyright">{{ .Site.Params.footer.copyright_text | safeHTML }}</div>
+          {{ with .Site.Params.footer.copyright_text }}
+            <div class="copyright">{{ . | safeHTML }}</div>
           {{ end }}
         </div>
       </div>

--- a/layouts/services/single.html
+++ b/layouts/services/single.html
@@ -17,9 +17,8 @@
 {{ $library := resources.Get "js/libs/library.js" }}
 {{ $services := resources.Get "js/pages/services.js" }}
 {{ $servicesJS := slice $library $services | resources.Concat "js/services.js" }}
-{{ if .Site.IsServer }}
-  <script type="text/javascript" src="{{ $servicesJS.RelPermalink }}"></script>
-  {{ else }}
-  <script type="text/javascript" src="{{ ($servicesJS | minify | fingerprint).RelPermalink }}"></script>
-  {{ end }}
+{{ if hugo.IsProduction }}
+  {{ $servicesJS = $servicesJS | minify | fingerprint }}
+{{ end }}
+<script type="text/javascript" src="{{ $servicesJS.RelPermalink }}"></script>
 {{ end }}

--- a/layouts/services/single.html
+++ b/layouts/services/single.html
@@ -16,7 +16,7 @@
 {{ define "footer_js" }}
 {{ $library := resources.Get "js/libs/library.js" }}
 {{ $services := resources.Get "js/pages/services.js" }}
-{{ $servicesJS := slice $library $services |resources.Concat "js/services.js" }}
+{{ $servicesJS := slice $library $services | resources.Concat "js/services.js" }}
 {{ if .Site.IsServer }}
   <script type="text/javascript" src="{{ $servicesJS.RelPermalink }}"></script>
   {{ else }}


### PR DESCRIPTION
These changes reduce code repetition and use `hugo.IsProduction` to check for production builds instead of or in addition to `.Site.IsServer`. `hugo.IsProduction` is the same as `not .Site.IsServer` by default, but users can manually set the build environment and override this.