### PR TITLE
Fix home page not marked as active in menu

### DIFF
--- a/layouts/partials/footer-menu.html
+++ b/layouts/partials/footer-menu.html
@@ -3,7 +3,7 @@
     {{ $currentPage := . }}
     {{ range .Site.Menus.footer }}
     {{ $active := or ($currentPage.IsMenuCurrent "footer" .) ($currentPage.HasMenuCurrent "footer" .) }}
-    {{ $active = or $active (eq .Name $currentPage.Title) }}
+    {{ $active = or $active (eq (.URL | relLangURL) ($currentPage.RelPermalink | relLangURL)) }}
     <li class="menu-item-{{ .Name | lower }} {{ if $active }}active{{ end }}">
       <a href="{{.URL}}">
         {{ .Pre }}

--- a/layouts/partials/main-menu-mobile.html
+++ b/layouts/partials/main-menu-mobile.html
@@ -2,7 +2,9 @@
   <ul>
     {{ $currentPage := . }}
     {{ range .Site.Menus.main }}
-    <li class="menu-item-{{ .Name | lower }}{{ if $currentPage.IsMenuCurrent "main" . }} active{{ end }}">
+    {{ $active := or ($currentPage.IsMenuCurrent "footer" .) ($currentPage.HasMenuCurrent "footer" .) }}
+    {{ $active = or $active (eq (.URL | relLangURL) ($currentPage.RelPermalink | relLangURL)) }}
+    <li class="menu-item-{{ .Name | lower }} {{ if $active }}active{{ end }}">
       <a href="{{ .URL }}">
         <span>{{ .Name }}</span>
       </a>

--- a/layouts/partials/main-menu-mobile.html
+++ b/layouts/partials/main-menu-mobile.html
@@ -2,7 +2,7 @@
   <ul>
     {{ $currentPage := . }}
     {{ range .Site.Menus.main }}
-    {{ $active := or ($currentPage.IsMenuCurrent "footer" .) ($currentPage.HasMenuCurrent "footer" .) }}
+    {{ $active := or ($currentPage.IsMenuCurrent "main" .) ($currentPage.HasMenuCurrent "main" .) }}
     {{ $active = or $active (eq (.URL | relLangURL) ($currentPage.RelPermalink | relLangURL)) }}
     <li class="menu-item-{{ .Name | lower }} {{ if $active }}active{{ end }}">
       <a href="{{ .URL }}">

--- a/layouts/partials/main-menu.html
+++ b/layouts/partials/main-menu.html
@@ -3,7 +3,7 @@
     {{ $currentPage := . }}
     {{ range .Site.Menus.main }}
     {{ $active := or ($currentPage.IsMenuCurrent "main" .) ($currentPage.HasMenuCurrent "main" .) }}
-    {{ $active = or $active (eq .Name $currentPage.Title) }}
+    {{ $active = or $active (eq (.URL | relLangURL) ($currentPage.RelPermalink | relLangURL)) }}
     <li class="menu-item-{{ .Name | lower }} {{ if $active }}active{{ end }}">
       <a href="{{.URL}}">
         {{ .Pre }}


### PR DESCRIPTION
Previously, with a menu item as follows, the "Home" link did not get
the `active` CSS class and was thus not styled as such.

```toml
[[menu.main]]
name = "Home"
url = "/"
weight = 1
```

The approach used here to determine whether the current page
corresponds to a certain menu entry was inspired by the one suggested
at https://stackoverflow.com/a/56454338. It is supposedly also more
robust when dealing with multilingual sites.