### PR TITLE
Fix "View All Services" button config conditional

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -31,7 +31,7 @@
       </div>
       {{ end }}
     </div>
-    {{ if not .Site.Params.homepage.show_services_button }}
+    {{ if .Site.Params.homepage.show_services_button }}
     <div class="row justify-content-center">
       <div class="col-auto">
         <a class="button button-primary" href="{{ "services/" | relURL }}">View All Services</a>


### PR DESCRIPTION
Previously, the button would be shown if and only if `show_services_button` was set to `false`. This change inverts that conditional.

**NOTE:** This change will potentially break existing sites.