### PR TITLE
Avoid summary link target issue when deployed to CloudFlare pages

### DIFF
--- a/layouts/_default/summary.html
+++ b/layouts/_default/summary.html
@@ -1,6 +1,6 @@
 <div class="summary">
     <h2>
-      <a href="{{ .Permalink }}">{{ .Title }}</a>
+      <a href="{{ .RelPermalink }}">{{ .Title }}</a>
     </h2>
     {{ .Content | truncate 120 "…" }}
 </div>

--- a/layouts/services/summary.html
+++ b/layouts/services/summary.html
@@ -1,7 +1,7 @@
 <div class="service service-summary">
   <div class="service-content">
     <h2 class="service-title">
-      <a href="{{ .Permalink }}">{{ .Title }}</a>
+      <a href="{{ .RelPermalink }}">{{ .Title }}</a>
     </h2>
     <p>{{ .Content | plainify | htmlUnescape | truncate 120 "…" }}</p>
   </div>


### PR DESCRIPTION
This issue is caused by the same mechanism as described in https://github.com/zerostaticthemes/hugo-serif-theme/pull/62. Please let me know if you prefer to have the PRs and/or commits merged (given that you like the changes and would like them merged).

---

From
https://developers.cloudflare.com/pages/framework-guides/deploy-a-hugo-site/#deploying-with-cloudflare-pages:

    Hugo allows you to configure the baseURL of your application. This
    allows you to utilize the absURL helper to construct full
    canonical URLs. In order to do this with Pages, you must provde
    the -b or --baseURL flags with the CF_PAGES_URL environment
    variable to your hugo build command.

Using the advice above, the baseURL is set to the specific deployment
URL by CloudFlare, e.g.
https://848e759b.my-project-name-here.pages.dev.

Let's say now that 848e759b is the most recent production build. That
means the same version is available at my-project-name-here.pages.dev.

Now, when visiting https://my-project-name-here.pages.dev/, however,
the target for any link using `{{ .Permalink }}` will point to
https://848e759b.my-project-name-here.pages.dev instead of
https://my-project-name-here.pages.dev/.

By using the relative permalink instead, the issues is avoided
altogether.