### PR TITLE
Allow services summary truncation to be configurable

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -43,6 +43,9 @@ title = "Hugo Serif Theme"
     meta_twitter_creator = "@zerostaticio"
     meta_og_image = "https://www.zerostatic.io/theme/hugo-serif/hugo-serif-screenshot.png"
 
+  [params.services]
+    summary_truncate = 120 # How many characters to include in the summary of the services before truncating
+
   [params.team]
     summary_large_truncate = 120 # How many characters to include in the summary of the team bios (large layout) before truncating
 

--- a/layouts/services/summary.html
+++ b/layouts/services/summary.html
@@ -3,6 +3,6 @@
     <h2 class="service-title">
       <a href="{{ .RelPermalink }}">{{ .Title }}</a>
     </h2>
-    <p>{{ .Content | plainify | htmlUnescape | truncate 120 "…" }}</p>
+    <p>{{ .Content | plainify | htmlUnescape | truncate (.Site.Params.services.summary_truncate | default 120 ) "…" }}</p>
   </div>
 </div>


### PR DESCRIPTION
Since we had similar configuration option for teams summary, I felt this would be a nice option to be configurable as well for services summary.