### PR TITLE
fix: remove erroneous space in service button

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -35,7 +35,7 @@
     {{ if .Site.Params.homepage.show_services_button }}
     <div class="row justify-content-center">
       <div class="col-auto">
-        <a class="button button-primary" href="{{ " services/" | relURL }}">View All Services</a>
+        <a class="button button-primary" href="{{ "services/" | relURL }}">View All Services</a>
       </div>
     </div>
     {{ end }}


### PR DESCRIPTION
Obviously commit 68ffe63314771ca4fd1c9a167566c024fadbe540 added an erroneous space in the link target and thereby breaks the services button.