### PR TITLE
fix(services): use summary instead of whole content

### DIFF
--- a/layouts/_default/summary.html
+++ b/layouts/_default/summary.html
@@ -2,5 +2,5 @@
     <h2>
       <a href="{{ .RelPermalink }}">{{ .Title }}</a>
     </h2>
-    {{ .Content | truncate 120 "…" }}
+    {{ .Summary | truncate 120 "…" }}
 </div>

--- a/layouts/services/summary.html
+++ b/layouts/services/summary.html
@@ -3,6 +3,6 @@
     <h2 class="service-title">
       <a href="{{ .RelPermalink }}">{{ .Title }}</a>
     </h2>
-    <p>{{ .Content | plainify | htmlUnescape | truncate (.Site.Params.services.summary_truncate | default 120 ) "…" }}</p>
+    <p>{{ .Summary | plainify | htmlUnescape | truncate (.Site.Params.services.summary_truncate | default 120 ) "…" }}</p>
   </div>
 </div>


### PR DESCRIPTION
Hello 👋

There is no need to always have the "..." for a service presentation if the first paragraph is less than 120 characters.

By putting `<!--more-->` in a service page, this MR will avoid the "..." on the homepage / services pages.

And in case the `<!--more-->` is missing, whole content will be used.

Win-win, no?

Cheers :)