### PR TITLE
Add summaryLength to config.toml

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -3,6 +3,7 @@ themesDir = "themes"
 theme = "hugo-serif-theme"
 languageCode = "en-us"
 title = "Hugo Serif Theme"
+summaryLength = 10
 
 [module]
   [module.hugoVersion]


### PR DESCRIPTION
The content of the services shown on the main page is quite large. Using this parameter restricts the length of the summary.