### PR TITLE
Add link on team member name pointing to their full pages

### DIFF
--- a/layouts/team/single.html
+++ b/layouts/team/single.html
@@ -1,0 +1,25 @@
+{{ define "body_classes" }}page-default-single{{ end }}
+
+{{ define "main" }}
+<div class="container pb-6 pt-6 pt-md-14 pb-md-14">
+  <div class="row justify-content-start">
+    <div class="col-12 col-md-8">
+      {{ if .Params.image }}
+        <div>
+          <img width="320" height="320" alt="Photo of {{ .Title }}" class="img-fluid mb-2" src="{{ .Params.image | relURL }}" />
+        </div>
+      {{ end }}
+      <div class="team-summary">
+        <div class="team-meta mb-2">
+          <h1 class="team-name">{{ .Title }}</h1>
+          <p class="team-description">{{ .Params.Jobtitle }}</p>
+          {{ if .Params.Linkedinurl }}
+            <a target="_blank" rel="noreferrer" href="{{ .Params.Linkedinurl }}">LinkedIn</a>
+          {{ end }}
+        </div>
+        <div class="content">{{.Content}}</div>
+      </div>
+    </div>
+  </div>
+</div>
+{{ end }}

--- a/layouts/team/summary-large.html
+++ b/layouts/team/summary-large.html
@@ -5,7 +5,9 @@
   </div>
   {{ end }}
   <div class="team-meta">
-    <h2 class="team-name">{{ .Title }}</h2>
+    <h2 class="team-name">
+      <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+    </h2>
     <p class="team-description">{{ .Params.Jobtitle }}</p>
     {{ if .Params.Linkedinurl }}
     <a target="_blank" rel="noreferrer" href="{{ .Params.Linkedinurl }}">LinkedIn</a> {{ end }}

--- a/layouts/team/summary.html
+++ b/layouts/team/summary.html
@@ -5,10 +5,12 @@
   </div>
   {{ end }}
   <div class="team-meta">
-    <h2 class="team-name">{{ .Title }}</h2>
+    <h2 class="team-name">
+      <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+    </h2>
     <p class="team-description">{{ .Params.Jobtitle }}</p>
     {{ if .Params.Linkedinurl }}
-      <a target="_blank" rel="noreferrer" href="{{ .Params.Linkedinurl }}">LinkedIn</a> 
+      <a target="_blank" rel="noreferrer" href="{{ .Params.Linkedinurl }}">LinkedIn</a>
     {{ end }}
   </div>
   <div class="team-content"></div>


### PR DESCRIPTION
Pull request to resolve issue #69
- Added a link to each team member's name on the team page pointing to their individual pages.
- Created a layout for an individual team member that displays the name, title, LinkedIn URL, and content of the individual team member.
- Screenshot of the actual layout:![team-member-page-screenshot](https://github.com/zerostaticthemes/hugo-serif-theme/assets/37213663/d7442f55-dd81-483c-b5dd-4deaf7531db5)