### PR TITLE
Update deprecated .Site.IsServer method 

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -9,7 +9,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <!-- CSS-->
-  {{ if .Site.IsServer }}
+  {{ if hugo.IsServer }}
   {{ $style := resources.Get "scss/style.scss" | resources.ExecuteAsTemplate "style.scss" . | toCSS (dict "targetPath" "css/style.css" "enableSourceMap" true) }}
   <link rel="stylesheet" href="{{ ($style).RelPermalink }}">
   {{ else }}

--- a/layouts/partials/google-analytics.html
+++ b/layouts/partials/google-analytics.html
@@ -1,4 +1,4 @@
-{{- if and (not .Site.IsServer) hugo.IsProduction -}}
+{{- if and (not hugo.IsServer) hugo.IsProduction -}}
 {{ with getenv "HUGO_GOOGLE_ANALYTICS_ID" | default .Site.Params.google_analytics_id }}
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id={{- . -}}"></script>

--- a/layouts/partials/google-tag-manager-noscript.html
+++ b/layouts/partials/google-tag-manager-noscript.html
@@ -1,4 +1,4 @@
-{{- if and (not .Site.IsServer) hugo.IsProduction -}}
+{{- if and (not hugo.IsServer) hugo.IsProduction -}}
 {{ with getenv "HUGO_GTM_ID" | default .Site.Params.google_tag_manager_id }}
 <!-- Google Tag Manager (noscript) --> <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ . }}" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript> <!-- End Google Tag Manager (noscript) -->
 {{ end }}

--- a/layouts/partials/google-tag-manager.html
+++ b/layouts/partials/google-tag-manager.html
@@ -1,4 +1,4 @@
-{{- if and (not .Site.IsServer) hugo.IsProduction -}}
+{{- if and (not hugo.IsServer) hugo.IsProduction -}}
 {{ with getenv "HUGO_GTM_ID" | default .Site.Params.google_tag_manager_id }}
 <!-- Google Tag Manager --> <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src= 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer','{{ . }}');</script> <!-- End Google Tag Manager -->
 {{ end }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,8 +1,8 @@
 [build]
   publish = "exampleSite/public"
-  command = "cd exampleSite && hugo --gc --themesDir ../.."
+  command = "cd exampleSite && hugo --gc"
 
 [build.environment]
-  HUGO_VERSION = "0.80.0"
-  HUGO_THEME = "repo"
+  HUGO_VERSION = "0.132.0"
+  HUGO_THEME = "../.."
   HUGO_BASEURL = "/"


### PR DESCRIPTION
Build with recent hugo versions fails with:
```
hugo v0.132.1+extended linux/amd64 BuildDate=unknown
ERROR deprecated: .Site.IsServer was deprecated in Hugo v0.120.0 and will be removed in Hugo 0.133.0. Use hugo.IsServer instead.
```

https://gohugo.io/methods/site/isserver/